### PR TITLE
Prevent breakage of other behat tests

### DIFF
--- a/db/install.php
+++ b/db/install.php
@@ -28,7 +28,8 @@
  */
 function xmldb_tool_courserating_install() {
 
-    if (!defined('PHPUNIT_TEST') || !PHPUNIT_TEST) {
+    if ((!defined('PHPUNIT_TEST') || !PHPUNIT_TEST)
+        && (!defined('BEHAT_UTIL') || !BEHAT_UTIL)){
         \tool_courserating\task\reindex::schedule();
     }
     return true;

--- a/settings.php
+++ b/settings.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 if ($hassiteconfig) {
 
     // Disable ratings in unittests by default, otherwise it breaks core tests.
-    $isunittest = defined('PHPUNIT_TEST') && PHPUNIT_TEST;
+    $isunittest = (defined('PHPUNIT_TEST') && PHPUNIT_TEST) || (defined('BEHAT_UTIL') && BEHAT_UTIL);
 
     $temp = new admin_settingpage('tool_courserating', new lang_string('pluginname', 'tool_courserating'));
     $el = new admin_setting_configselect('tool_courserating/' . \tool_courserating\constants::SETTING_RATINGMODE,

--- a/tests/behat/behat_tool_courserating.php
+++ b/tests/behat/behat_tool_courserating.php
@@ -28,6 +28,20 @@ require_once(__DIR__ . '/../../../../../lib/behat/behat_base.php');
  */
 class behat_tool_courserating extends behat_base {
 
+    /**
+     * Adds "Course rating" custom field that would be otherwise breaking other tests.
+     *
+     * @Given Course ratings are enabled for all students
+     */
+    public function create_course_rating_field(): void {
+        // Custom fields API is not designed to be used from behat steps, so try to hack around it somehow.
+        $reflection = new \ReflectionProperty(\core_course\customfield\course_handler::class, 'singleton');
+        $reflection->setAccessible(true);
+        $reflection->setValue(null, null);
+
+        set_config(\tool_courserating\constants::SETTING_RATINGMODE, \tool_courserating\constants::RATEBY_ANYTIME, 'tool_courserating');
+        \tool_courserating\api::reindex(0);
+    }
 
     /**
      * Return the list of partial named selectors.

--- a/tests/behat/student.feature
+++ b/tests/behat/student.feature
@@ -2,7 +2,8 @@
 Feature: Viewing and adding course ratings as a student
 
   Background:
-    Given the following "courses" exist:
+    Given Course ratings are enabled for all students
+    And the following "courses" exist:
       | fullname | shortname | numsections |
       | Course 1 | C1        | 1           |
       | Course 2 | C2        | 1           |

--- a/tests/behat/teacher.feature
+++ b/tests/behat/teacher.feature
@@ -2,7 +2,8 @@
 Feature: Viewing and managing course ratings as a teacher and manager
 
   Background:
-    Given the following "courses" exist:
+    Given Course ratings are enabled for all students
+    And the following "courses" exist:
       | fullname | shortname | numsections |
       | Course 1 | C1        | 1           |
       | Course 2 | C2        | 1           |


### PR DESCRIPTION
Some other tests are not referencing custom fields properly which may lead to test failures when
course rating field is present.

Workaround is to create the custom field only
in own tests.

```
008 Scenario: Edit a custom course date field                                        # /builds/open-lms/product/work/moodle/customfield/field/date/tests/behat/field.feature:24
      And I click on "Save changes" "button" in the "Updating Test field" "dialogue" # /builds/open-lms/product/work/moodle/customfield/field/date/tests/behat/field.feature:34
        Dialogue matching locator "'Updating Test field'" not found. (Behat\Mink\Exception\ElementNotFoundException)
009 Scenario: Delete a custom course date field # /builds/open-lms/product/work/moodle/customfield/field/date/tests/behat/field.feature:38
      Then I should not see "Test field"        # /builds/open-lms/product/work/moodle/customfield/field/date/tests/behat/field.feature:47
        "Test field" text was found in the page (Behat\Mink\Exception\ExpectationException)

```